### PR TITLE
Improved grid definition with global parameters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,8 @@ module.exports = function(grunt) {
         less: {
             production: {
                 options: {
-                    compress: true
+                    compress: true,
+                    modifyVars: cleanUpInputLessGridVars()
                 },
                 files: {
                     "dist/css-essentials-min.css": "src/all.less"
@@ -35,4 +36,29 @@ module.exports = function(grunt) {
     });
     grunt.registerTask('release', ['less:production']);
     grunt.registerTask('demo', ['less:production', 'copy:demo', 'connect:demo']);
+
+    function cleanUpInputLessGridVars() {
+      var lessModifyVars = {
+        'of-xsm' : grunt.option('xsm'),
+        'of-sm'  : grunt.option('sm'),
+        'of-md'  : grunt.option('md'),
+        'of-lg'  : grunt.option('lg'),
+        'of-xlg' : grunt.option('xlg'),
+        'of-xxlg': grunt.option('xxlg')
+      };
+
+      var counter = 0;
+      for(var key in lessModifyVars) {
+        var value = lessModifyVars[key];
+        if (value === undefined || value === null) {
+          delete lessModifyVars[key];
+        } else {
+          counter = counter + 1;
+        }
+      }
+      if (counter === 0) {
+        lessModifyVars = undefined;
+      }
+      return lessModifyVars;
+    }
 };

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We'll try to keep it up to date and continuously add cool new features.
 
 ### Demo
 
-You can see the demo [here] (http://5minfork.com/onefootball/css-essentials), just navigate to demo folder. 
+You can see the demo [here] (http://5minfork.com/onefootball/css-essentials), just navigate to demo folder.
 
 ### Issues and questions
 
@@ -83,9 +83,9 @@ Row padding can be omitted using
 
 ##### Loading spinner
 
-Loading spinner can be used to indicate loading. 
+Loading spinner can be used to indicate loading.
 
-Quick start: 
+Quick start:
 
 ```xml
 <div class="of-row">
@@ -100,9 +100,9 @@ Quick start:
 
 ##### Truncate text
 
-Truncate text is usefull, when you want to display text in one line and truncate it, if it exceeds the width of a line. 
+Truncate text is usefull, when you want to display text in one line and truncate it, if it exceeds the width of a line.
 
-Quick start: 
+Quick start:
 
 ```xml
 <div class="of-row">
@@ -124,13 +124,43 @@ Quick start:
 
 ##### Push up animation
 
-Push up animation is a nice effect for hovering on elements. 
+Push up animation is a nice effect for hovering on elements.
 
-Quick start: 
+Quick start:
 
-Just append 
+Just append
 
 ```xml
 .of-push-up-animation
 ```
 class to any of your elements.
+
+
+### Customization
+
+It is possible to edit the grid breakpoints by editing the values in the `src/base/breakpoints.less` file and then recompiling the project.
+
+```shell
+
+$ npm install && grunt release
+
+```
+
+#### Command Line Values
+
+In addition to this, it is possible to pass in, to the grunt command, the desired values for the grid breakpoints:
+
+```shell
+$ npm install && grunt release --xsm='300px' --sm='400px' --md='500px' --lg='600px' --xlg='700px' --xxlg='800px'
+
+```
+
+This would generate a file in the dist folder with the given values.
+The accepted variables are:
+
+- --xsm
+- --sm
+- --md
+- --lg
+- --xlg
+- --xxlg

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt": "0.4.5",
     "grunt-contrib-connect": "0.11.2",
     "grunt-contrib-copy": "0.8.2",
-    "grunt-contrib-less": "1.1.0",
+    "grunt-contrib-less": "1.3.0",
     "load-grunt-tasks": "3.4.0"
   }
 }


### PR DESCRIPTION
With this change, will be possible to overwrite the variables of the grid system from the command line.

Example:

```bash

$ grunt release --xsm='100px' --sm='200px' --md='300px' --lg='400px' --xlg='500px' --xxlg='600px'

```

When one of those variable is omitted the one from `src/base/breakpoints.less` is taken as usual.